### PR TITLE
feat: Change Node-Traits to all accept mut-refs.

### DIFF
--- a/src/exec/execution.rs
+++ b/src/exec/execution.rs
@@ -176,6 +176,7 @@ impl Executor for StandardExecutor {
         S: Scheduler + std::marker::Send,
         U: NodeUpdater + Drop,
     {
+        let mut flow = flow;
         //TODO: Fix error flow.
 
         flow.init_all()

--- a/src/flow/flow.rs
+++ b/src/flow/flow.rs
@@ -92,7 +92,7 @@ impl Flow {
         self.nodes.len()
     }
 
-    pub fn init_all(&self) -> Result<()> {
+    pub fn init_all(&mut self) -> Result<()> {
         for n in &self.nodes {
             n.1
                 .lock()
@@ -103,7 +103,7 @@ impl Flow {
         Ok(())
     }
 
-    pub fn shutdown_all(&self) -> Result<()> {
+    pub fn shutdown_all(&mut self) -> Result<()> {
         for n in &self.nodes {
             n.1
                 .lock()
@@ -114,7 +114,7 @@ impl Flow {
         Ok(())
     }
 
-    pub fn ready_all(&self) -> Result<()> {
+    pub fn ready_all(&mut self) -> Result<()> {
         for n in &self.nodes {
 
             n.1

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -69,13 +69,13 @@ pub trait UpdateController {
 /// Contains methods for each state in the lifecycle of a node. 
 pub trait Node : Send {
     /// This method is called for node initialization.
-    fn on_init(&self) -> Result<(), InitError> { Ok(())}
+    fn on_init(&mut self) -> Result<(), InitError> { Ok(())}
 
     /// This method is called when all nodes in the flow are initialized.
-    fn on_ready(&self) -> Result<(), ReadyError> { Ok(())}
+    fn on_ready(&mut self) -> Result<(), ReadyError> { Ok(())}
 
     /// This method is called when flow execution ends.
-    fn on_shutdown(&self) -> Result<(), ShutdownError> { Ok(())}
+    fn on_shutdown(&mut self) -> Result<(), ShutdownError> { Ok(())}
 
     /// This method is called by the executor dependent on its update strategy. 
     fn on_update(&mut self) -> Result<(), UpdateError> { Ok(())}

--- a/tests/sched/test_execution.rs
+++ b/tests/sched/test_execution.rs
@@ -23,7 +23,7 @@ impl DummyNode {
 }
 
 impl Node for DummyNode {
-    fn on_init(&self) -> Result<(), InitError> {
+    fn on_init(&mut self) -> Result<(), InitError> {
         if self.err_on_init {
             let _file = File::open("").map_err(|err| InitError::Other(err.into()))?;
         }


### PR DESCRIPTION
Considering a statefull node, non-mutable on_init, on_ready or on_shutdown are not allowing any states to be stored or modified. Since now one had to initialize this in the on_update method which does not really make sense.

Breaking changes: This needs to be adapted for every implenetation of on_init, on_ready and on_shutdown